### PR TITLE
refactor(noti): use `Date.now()` instead of `new Date().getTime()`

### DIFF
--- a/packages/core/src/composables/useCreateNoti.ts
+++ b/packages/core/src/composables/useCreateNoti.ts
@@ -37,8 +37,7 @@ export function useCreateNoti(options: UseCreateNotiOptions) {
 
   function triggerCountDown(target: Notification) {
     const interval = setInterval(() => {
-      const now = new Date()
-      const lastTime = target.timer.endCountDownTimestamp - now.getTime()
+      const lastTime = target.timer.endCountDownTimestamp - Date.now()
       if (lastTime > 0) {
         target.timer.lastTime = lastTime
         return


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Use `Date.now()` instead of `new Date().getTime()`. They are effectively equivalent, but `Date.now()` code is shorter and performs better.

### 📝 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/Rock070/vue3-noti/blob/main/CONTRIBUTING.md).
- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
