### PR TITLE
perf(noti): avoid unnecessary loop execution

### DIFF
--- a/packages/core/src/composables/useCreateNoti.ts
+++ b/packages/core/src/composables/useCreateNoti.ts
@@ -102,12 +102,8 @@ export function useCreateNoti(options: UseCreateNotiOptions) {
       return
     }
 
-    belongGroup.push(item)
-
-    const target = belongGroup.find(i => i.id === item.id)
-
-    if (!target)
-      return
+    const length = belongGroup.push(item)
+    const target = belongGroup[length - 1]!
 
     triggerCountDown(target)
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, we will push `noti` into `belongGroup`, and will get `noti` from `belongGroup` again, because, we need 

https://github.com/Rock070/vue3-noti/blob/9b8774bec89cd4772a5235cdd14c206817b43a2b/packages/core/src/composables/useCreateNoti.ts#L105-L107C5

Now, we push `noti` into `belongGroup` and get `noti` from `belongGroup` again, because we need to turn `noti` into responsive data through this operation.

The way we get out `noti` again is to use `Array.prototype.find`, but we have other ways to avoid the execution of the loop

1. Directly convert `noti` into responsive data
2. Use a more direct method to get `noti` from `belongGroup`

The first method may be more intuitive, but will change the return value of the `notify` function, so this PR uses the second method.

### 📝 Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/Rock070/vue3-noti/blob/main/CONTRIBUTING.md).
- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
